### PR TITLE
Add prefixes to Logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -8,6 +8,7 @@ type FieldsArr []interface{}
 
 // Logger is the interface that represents a logging unit.
 type Logger interface {
+	WithPrefix(prefix string) Logger
 	WithField(name string, value interface{}) Logger
 	WithFields(fields Fields) Logger
 	WithFieldsArr(fields ...interface{}) Logger
@@ -33,6 +34,7 @@ type Logger interface {
 // additional information to the entries triggered by it.
 type subLogger struct {
 	logger                Logger
+	prefix                string
 	additionalInformation string
 	additionalFields      FieldsArr
 }
@@ -43,6 +45,12 @@ func newSubLogger(logger Logger, fields FieldsArr) *subLogger {
 		additionalInformation: logger.Formatter().FormatFields(fields),
 		additionalFields:      fields,
 	}
+}
+
+func (logger *subLogger) WithPrefix(prefix string) Logger {
+	l := newSubLogger(logger, nil)
+	l.prefix = prefix
+	return l
 }
 
 func (logger *subLogger) WithField(name string, value interface{}) Logger {
@@ -79,7 +87,18 @@ func (logger *subLogger) BasicLog(logLevel Level, traceLevel int, additionalInfo
 	} else {
 		ai = additionalInformation
 	}
+	if logger.prefix != "" {
+		if format == "" {
+			a = append([]interface{}{logger.prefix}, a...)
+		} else {
+			format = logger.prefix + format
+		}
+	}
 	logger.logger.BasicLog(logLevel, traceLevel, ai, append(logger.additionalFields, fields...), format, a...)
+}
+
+func (logger *subLogger) internalLog(logLevel Level, traceLevel int, format string, a ...interface{}) {
+	logger.logger.BasicLog(logLevel, traceLevel, logger.additionalInformation, logger.additionalFields, format, a...)
 }
 
 // Trace is for low level tracing of activities. It takes an additional 'level'
@@ -89,45 +108,45 @@ func (logger *subLogger) BasicLog(logLevel Level, traceLevel int, additionalInfo
 // all then no trace messages are printed.
 func (logger *subLogger) Trace(traceLevel int, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelTrace, traceLevel, logger.additionalInformation, logger.additionalFields, "", a...)
+		logger.internalLog(levelTrace, traceLevel, "", a...)
 	} else {
-		logger.logger.BasicLog(levelTrace, traceLevel, "", nil, "", a...)
+		logger.internalLog(levelTrace, traceLevel, "", a...)
 	}
 }
 
 // Tracef prints trace messages, with formatting.
 func (logger *subLogger) Tracef(traceLevel int, format string, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelTrace, traceLevel, logger.additionalInformation, logger.additionalFields, format, a...)
+		logger.internalLog(levelTrace, traceLevel, format, a...)
 	} else {
-		logger.logger.BasicLog(levelTrace, traceLevel, "", nil, format, a...)
+		logger.internalLog(levelTrace, traceLevel, format, a...)
 	}
 }
 
 // Debug prints a message if RLOG_LEVEL is set to DEBUG.
 func (logger *subLogger) Debug(a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelDebug, notATrace, logger.additionalInformation, logger.additionalFields, "", a...)
+		logger.internalLog(levelDebug, notATrace, "", a...)
 	} else {
-		logger.logger.BasicLog(levelDebug, notATrace, "", nil, "", a...)
+		logger.internalLog(levelDebug, notATrace, "", a...)
 	}
 }
 
 // Debugf prints a message if RLOG_LEVEL is set to DEBUG, with formatting.
 func (logger *subLogger) Debugf(format string, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelDebug, notATrace, logger.additionalInformation, logger.additionalFields, format, a...)
+		logger.internalLog(levelDebug, notATrace, format, a...)
 	} else {
-		logger.logger.BasicLog(levelDebug, notATrace, "", nil, format, a...)
+		logger.internalLog(levelDebug, notATrace, format, a...)
 	}
 }
 
 // Info prints a message if RLOG_LEVEL is set to INFO or lower.
 func (logger *subLogger) Info(a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelInfo, notATrace, logger.additionalInformation, logger.additionalFields, "", a...)
+		logger.internalLog(levelInfo, notATrace, "", a...)
 	} else {
-		logger.logger.BasicLog(levelInfo, notATrace, "", nil, "", a...)
+		logger.internalLog(levelInfo, notATrace, "", a...)
 	}
 }
 
@@ -135,9 +154,9 @@ func (logger *subLogger) Info(a ...interface{}) {
 // formatting.
 func (logger *subLogger) Infof(format string, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelInfo, notATrace, logger.additionalInformation, logger.additionalFields, format, a...)
+		logger.internalLog(levelInfo, notATrace, format, a...)
 	} else {
-		logger.logger.BasicLog(levelInfo, notATrace, "", nil, format, a...)
+		logger.internalLog(levelInfo, notATrace, format, a...)
 	}
 }
 
@@ -146,9 +165,9 @@ func (logger *subLogger) Infof(format string, a ...interface{}) {
 // with standard log package, directly using Info is preferred way.
 func (logger *subLogger) Println(a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelInfo, notATrace, logger.additionalInformation, logger.additionalFields, "", a...)
+		logger.internalLog(levelInfo, notATrace, "", a...)
 	} else {
-		logger.logger.BasicLog(levelInfo, notATrace, "", nil, "", a...)
+		logger.internalLog(levelInfo, notATrace, "", a...)
 	}
 }
 
@@ -158,18 +177,18 @@ func (logger *subLogger) Println(a ...interface{}) {
 // with standard log package, directly using Infof is preferred way.
 func (logger *subLogger) Printf(format string, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelInfo, notATrace, logger.additionalInformation, logger.additionalFields, format, a...)
+		logger.internalLog(levelInfo, notATrace, format, a...)
 	} else {
-		logger.logger.BasicLog(levelInfo, notATrace, "", nil, format, a...)
+		logger.internalLog(levelInfo, notATrace, format, a...)
 	}
 }
 
 // Warn prints a message if RLOG_LEVEL is set to WARN or lower.
 func (logger *subLogger) Warn(a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelWarn, notATrace, logger.additionalInformation, logger.additionalFields, "", a...)
+		logger.internalLog(levelWarn, notATrace, "", a...)
 	} else {
-		logger.logger.BasicLog(levelWarn, notATrace, "", nil, "", a...)
+		logger.internalLog(levelWarn, notATrace, "", a...)
 	}
 }
 
@@ -177,18 +196,18 @@ func (logger *subLogger) Warn(a ...interface{}) {
 // formatting.
 func (logger *subLogger) Warnf(format string, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelWarn, notATrace, logger.additionalInformation, logger.additionalFields, format, a...)
+		logger.internalLog(levelWarn, notATrace, format, a...)
 	} else {
-		logger.logger.BasicLog(levelWarn, notATrace, "", nil, format, a...)
+		logger.internalLog(levelWarn, notATrace, format, a...)
 	}
 }
 
 // Error prints a message if RLOG_LEVEL is set to ERROR or lower.
 func (logger *subLogger) Error(a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelErr, notATrace, logger.additionalInformation, logger.additionalFields, "", a...)
+		logger.internalLog(levelErr, notATrace, "", a...)
 	} else {
-		logger.logger.BasicLog(levelErr, notATrace, "", nil, "", a...)
+		logger.internalLog(levelErr, notATrace, "", a...)
 	}
 }
 
@@ -196,18 +215,18 @@ func (logger *subLogger) Error(a ...interface{}) {
 // formatting.
 func (logger *subLogger) Errorf(format string, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelErr, notATrace, logger.additionalInformation, logger.additionalFields, format, a...)
+		logger.internalLog(levelErr, notATrace, format, a...)
 	} else {
-		logger.logger.BasicLog(levelErr, notATrace, "", nil, format, a...)
+		logger.internalLog(levelErr, notATrace, format, a...)
 	}
 }
 
 // Critical prints a message if RLOG_LEVEL is set to CRITICAL or lower.
 func (logger *subLogger) Critical(a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelCrit, notATrace, logger.additionalInformation, logger.additionalFields, "", a...)
+		logger.internalLog(levelCrit, notATrace, "", a...)
 	} else {
-		logger.logger.BasicLog(levelCrit, notATrace, "", nil, "", a...)
+		logger.internalLog(levelCrit, notATrace, "", a...)
 	}
 }
 
@@ -215,8 +234,8 @@ func (logger *subLogger) Critical(a ...interface{}) {
 // formatting.
 func (logger *subLogger) Criticalf(format string, a ...interface{}) {
 	if logger != nil {
-		logger.logger.BasicLog(levelCrit, notATrace, logger.additionalInformation, logger.additionalFields, format, a...)
+		logger.internalLog(levelCrit, notATrace, format, a...)
 	} else {
-		logger.logger.BasicLog(levelCrit, notATrace, "", nil, format, a...)
+		logger.internalLog(levelCrit, notATrace, format, a...)
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -1,7 +1,5 @@
 package rlog
 
-import "fmt"
-
 type Fields map[string]interface{}
 
 type FieldsArr []interface{}
@@ -82,9 +80,11 @@ func (logger *subLogger) Formatter() LogFormatter {
 
 func (logger *subLogger) BasicLog(logLevel Level, traceLevel int, additionalInformation string, fields FieldsArr, format string, a ...interface{}) {
 	ai := logger.additionalInformation
-	if len(ai) > 0 && len(additionalInformation) > 0 {
-		ai = fmt.Sprint(ai, logger.Formatter().Separator(), additionalInformation)
-	} else {
+	if len(ai) > 0 {
+		if len(additionalInformation) > 0 {
+			ai = ai + logger.Formatter().Separator() + additionalInformation
+		}
+	} else if len(additionalInformation) > 0 {
 		ai = additionalInformation
 	}
 	if logger.prefix != "" {
@@ -98,7 +98,7 @@ func (logger *subLogger) BasicLog(logLevel Level, traceLevel int, additionalInfo
 }
 
 func (logger *subLogger) internalLog(logLevel Level, traceLevel int, format string, a ...interface{}) {
-	logger.logger.BasicLog(logLevel, traceLevel, logger.additionalInformation, logger.additionalFields, format, a...)
+	logger.BasicLog(logLevel, traceLevel, "", nil, format, a...)
 }
 
 // Trace is for low level tracing of activities. It takes an additional 'level'

--- a/logger_test.go
+++ b/logger_test.go
@@ -88,4 +88,44 @@ level=INFO var1=value1 var2=value2 msg="this is in a sublogger"`))
 			})
 		})
 	})
+
+	Describe("WithPrefix", func() {
+		It("should add a prefix for non format functions", func() {
+			logger, err := NewLogger(Config{
+				LogNoTime:  true,
+				TraceLevel: "10",
+			})
+			buff := bytes.NewBuffer(nil)
+			logger.SetOutput(buff)
+			Expect(err).ToNot(HaveOccurred())
+			logger.Info("this is a INFO")
+
+			sublogger := logger.WithPrefix("prefix1").WithField("var1", "value1")
+			sublogger.Info("this is in a sublogger")
+
+			msgs := strings.Split(strings.TrimSpace(buff.String()), "\n")
+			Expect(msgs).To(HaveLen(2))
+			Expect(msgs[0]).To(Equal(`INFO[00000] this is a INFO`))
+			Expect(msgs[1]).To(Equal(`INFO[00000] prefix1this is in a sublogger                                var1=value1`))
+		})
+
+		It("should add a prefix for non format functions", func() {
+			logger, err := NewLogger(Config{
+				LogNoTime:  true,
+				TraceLevel: "10",
+			})
+			buff := bytes.NewBuffer(nil)
+			logger.SetOutput(buff)
+			Expect(err).ToNot(HaveOccurred())
+			logger.Infof("this is a INFO: %d", 1)
+
+			sublogger := logger.WithPrefix("prefix1").WithField("var1", "value1")
+			sublogger.Infof("this is in a sublogger: %d", 2)
+
+			msgs := strings.Split(strings.TrimSpace(buff.String()), "\n")
+			Expect(msgs).To(HaveLen(2))
+			Expect(msgs[0]).To(Equal(`INFO[00000] this is a INFO: 1`))
+			Expect(msgs[1]).To(Equal(`INFO[00000] prefix1this is in a sublogger: 2                             var1=value1`))
+		})
+	})
 })

--- a/logger_test.go
+++ b/logger_test.go
@@ -64,8 +64,10 @@ INFO[00000] this is in a sublogger                                       var1=va
 					"var1": "value1",
 				})
 				sublogger.Info("this is in a sublogger")
-				Expect(strings.TrimSpace(buff.String())).To(Equal(`level=INFO msg="this is a INFO"
-level=INFO var1=value1 msg="this is in a sublogger"`))
+				msgs := strings.Split(strings.TrimSpace(buff.String()), "\n")
+				Expect(msgs).To(HaveLen(2))
+				Expect(msgs[0]).To(Equal(`level=INFO msg="this is a INFO"`))
+				Expect(msgs[1]).To(Equal(`level=INFO var1=value1 msg="this is in a sublogger"`))
 			})
 
 			It("should aggregate fields in sequence", func() {
@@ -126,6 +128,25 @@ level=INFO var1=value1 var2=value2 msg="this is in a sublogger"`))
 			Expect(msgs).To(HaveLen(2))
 			Expect(msgs[0]).To(Equal(`INFO[00000] this is a INFO: 1`))
 			Expect(msgs[1]).To(Equal(`INFO[00000] prefix1this is in a sublogger: 2                             var1=value1`))
+		})
+
+		It("should add a prefix with 2 sublogger levels", func() {
+			logger, err := NewLogger(Config{
+				LogNoTime:  true,
+				TraceLevel: "10",
+			})
+			buff := bytes.NewBuffer(nil)
+			logger.SetOutput(buff)
+			Expect(err).ToNot(HaveOccurred())
+			logger.Info("this is a INFO")
+
+			sublogger := logger.WithPrefix("prefix1").WithField("var1", "value1").WithPrefix("prefix2")
+			sublogger.Info("this is in a sublogger")
+
+			msgs := strings.Split(strings.TrimSpace(buff.String()), "\n")
+			Expect(msgs).To(HaveLen(2))
+			Expect(msgs[0]).To(Equal(`INFO[00000] this is a INFO`))
+			Expect(msgs[1]).To(Equal(`INFO[00000] prefix1prefix2this is in a sublogger                         var1=value1`))
 		})
 	})
 })

--- a/rlog.go
+++ b/rlog.go
@@ -602,6 +602,12 @@ func (l *logger) BasicLog(logLevel Level, traceLevel int, additionalInformation 
 	ReleaseOutput(line)
 }
 
+func (l *logger) WithPrefix(prefix string) Logger {
+	sl := newSubLogger(l, nil)
+	sl.prefix = prefix
+	return sl
+}
+
 func (l *logger) WithField(name string, value interface{}) Logger {
 	return newSubLogger(l, FieldsArr{name, value})
 }

--- a/rlog_test.go
+++ b/rlog_test.go
@@ -255,7 +255,7 @@ var _ = Describe("RLog Test Suite", func() {
 			Expect(strings.TrimSpace(buff.String())).To(Equal(`level=ERROR msg="this is a ERROR with format enabled"`))
 		})
 
-		It("should ingore ERROR when level is CRITICAL", func() {
+		It("should ignore ERROR when level is CRITICAL", func() {
 			logger, err := NewLogger(Config{
 				Formatter: "text",
 				LogNoTime: true,
@@ -292,7 +292,7 @@ var _ = Describe("RLog Test Suite", func() {
 			Expect(strings.TrimSpace(buff.String())).To(Equal(`level=WARN msg="this is a WARN with format enabled"`))
 		})
 
-		It("should ingore WARN when level is CRITICAL", func() {
+		It("should ignore WARN when level is CRITICAL", func() {
 			logger, err := NewLogger(Config{
 				Formatter: "text",
 				LogNoTime: true,
@@ -329,7 +329,7 @@ var _ = Describe("RLog Test Suite", func() {
 			Expect(strings.TrimSpace(buff.String())).To(Equal(`level=INFO msg="this is a INFO with format enabled"`))
 		})
 
-		It("should ingore INFO when level is WARN", func() {
+		It("should ignore INFO when level is WARN", func() {
 			logger, err := NewLogger(Config{
 				Formatter: "text",
 				LogNoTime: true,
@@ -368,7 +368,7 @@ var _ = Describe("RLog Test Suite", func() {
 			Expect(strings.TrimSpace(buff.String())).To(Equal(`level=DEBUG msg="this is a DEBUG with format enabled"`))
 		})
 
-		It("should ingore DEBUG when level is INFO", func() {
+		It("should ignore DEBUG when level is INFO", func() {
 			logger, err := NewLogger(Config{
 				Formatter: "text",
 				LogLevel:  "INFO",
@@ -409,7 +409,7 @@ var _ = Describe("RLog Test Suite", func() {
 			Expect(strings.TrimSpace(buff.String())).To(Equal(`level=TRACE(1) msg="this is a TRACE with format enabled"`))
 		})
 
-		It("should ingore TRACE when trace level is greater than the set", func() {
+		It("should ignore TRACE when trace level is greater than the set", func() {
 			logger, err := NewLogger(Config{
 				Formatter:  "text",
 				LogLevel:   "DEBUG",


### PR DESCRIPTION
### :sparkles: Enhancements

*  `WithPrefix` method to the `Logger` interface;

### :bug: Bugs

* Fix error when passing `additionalInformation` as parameter to `subLogger.BasicLog` and there was already a `subLogger.additionalInformation` (it would be mistakenly discarded);
